### PR TITLE
Set hive.support.sql11.reserved.keywords=false for hive 1.2

### DIFF
--- a/parquet2hive/parquet2hive
+++ b/parquet2hive/parquet2hive
@@ -87,7 +87,7 @@ def main(dataset):
 
         partitions = get_partitioning_fields(sample.key[len(prefix):])
 
-        print "hive -e '{}'".format(avro2sql(schema, dataset_name, version, dataset, partitions))
+        print "hive -hiveconf hive.support.sql11.reserved.keywords=false -e '{}'".format(avro2sql(schema, dataset_name, version, dataset, partitions))
         if version_prefix == versions[-1][0]:  # Most recent version
             print "hive -e '{}'".format(avro2sql(schema, dataset_name, version, dataset, partitions, with_version=False))
 


### PR DESCRIPTION
https://cwiki.apache.org/confluence/display/Hive/Configuration+Properties
https://cwiki.apache.org/confluence/display/Hive/LanguageManual+DDL#LanguageManualDDL-ReservedKeywords
